### PR TITLE
Add dynamic hero button text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { useInView } from "react-intersection-observer";
 export default function Home() {
   const [currentTestimonial, setCurrentTestimonial] = useState(0);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const { scrollYProgress } = useScroll();
   const heroVideoRef = useRef<HTMLVideoElement>(null);
   const teamVideoRef = useRef<HTMLVideoElement>(null);
@@ -29,6 +30,20 @@ export default function Home() {
     if (teamVideoRef.current) {
       teamVideoRef.current.play();
     }
+  }, []);
+
+  useEffect(() => {
+    const checkLogin = () => {
+      const storedUserId = sessionStorage.getItem("userId");
+      setIsLoggedIn(!!storedUserId);
+    };
+
+    checkLogin();
+    window.addEventListener("storage", checkLogin);
+
+    return () => {
+      window.removeEventListener("storage", checkLogin);
+    };
   }, []);
 
   const testimonials = [
@@ -251,7 +266,7 @@ export default function Home() {
               className="group relative px-8 py-4 bg-gray-900 text-white rounded-2xl font-bold text-lg shadow-md overflow-hidden"
             >
               <span className="relative flex items-center gap-2">
-                Empieza ahora
+                {isLoggedIn ? "Análisis CV" : "Empieza ahora"}
                 <motion.svg
                   className="w-5 h-5"
                   fill="none"


### PR DESCRIPTION
## Summary
- detect login state on the landing page
- show "Análisis CV" in the hero button when logged in
- keep "Empieza ahora" when not logged in

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684718839f40832ea94da21978dd4925